### PR TITLE
test: Include Ningxia  (cn-northwest-1) region

### DIFF
--- a/test/integration/targets/ec2_ami/vars/main.yml
+++ b/test/integration/targets/ec2_ami/vars/main.yml
@@ -18,3 +18,4 @@ ec2_region_images:
   ap-south-1: ami-4fc58420
   sa-east-1: ami-f1344b9d
   cn-north-1: ami-fba67596
+  cn-northwest-1: ami-6c0b1e0e


### PR DESCRIPTION
### Summary

The region testing for China does not include the cn-northwest-1 or Ningxia region. 

Adding the AMI from cn-northwest-1. I reviewed the details from the cn-north-1 ami and located the identical AMI using the following command: # aws ec2 describe-images --region cn-northwest-1 --filters "Name=description,Values=Amazon Linux AMI 2017.09.0.20170930 x86_64 HVM GP2"

It's possible that the list is automatically generated and the cli version from which they are generated is out of date. 

### Issue Type
Bugfix Pull Request

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
